### PR TITLE
WIP: Use optional dep to fix Py3.4/pymatgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ install:
   - pip install ase==3.15.0
   - pip install --no-binary gpaw gpaw==1.3.0
   - gpaw install-data --register gpaw_setups
-  - pip install pymatgen
-  - pip install .
+  - pip install .[vasp]
 # command to run tests
 script:
   - xvfb-run coverage run --source galore setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ notifications:
   email: false
 python:
   - "3.4"
+  - "3.5"
   - "3.6"
 os:
   - linux

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Versioning <http://semver.org/>`__. The changelog format is inspired by
 
 `Unreleased <https://github.com/smtg-ucl/galore/compare/0.6.1...HEAD>`__
 -------------------------------------------------------------------------
+- Updated setup.py to add a [vasp] extra; this handles Pymatgen
+  installation which can be tricky on older Python versions.
 
 `[0.6.1] <https://github.com/smtg-ucl/galore/compare/0.6.0...0.6.1>`__ - 2018-11-19
 -----------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,13 @@ the galore library should be available on your PYTHONPATH. These are
 links to the project source folder, which you can continue to edit and
 update using Git.
 
+To import data from VASP calculations you will need the Pymatgen
+library. If you don't have Pymatgen yet, the requirements can be added
+to the Galore installation with by adding ``[vasp]`` to the pip
+command e.g.::
+
+   pip3 install --user -e .[vasp]
+
 Installation for documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ if __name__ == "__main__":
                                  'ruamel.yaml <= 0.15.94;python_version ~= "3.4"',
                                  'numpy ~= 1.16;python_version ~= "3.4"',
                                  'pymatgen <= 2019.6.20;python_version ~= "3.5"',
-                                 'pymatgen;python_version >= "3.6"']},
+                                 'pymatgen;python_version >= "3.6"',
+                                 'numpy >= 1.17;python_version >= "3.6"']},
         python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
         entry_points={
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,15 @@ if __name__ == "__main__":
         license='GPL v3',
 
         classifiers=[
-            'Development Status :: 4 - Beta',
+            'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-            'Natural Language :: English',
+            'Natural Language :: English', 
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.6',                     
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Physics'
             ],
@@ -56,7 +57,9 @@ if __name__ == "__main__":
         extras_require={'docs': ["sphinx",
                                  "sphinx_rtd_theme",
                                  "sphinx-argparse",
-                                 "sphinxcontrib-bibtex"]},
+                                 "sphinxcontrib-bibtex"],
+                        'vasp': ['pymatgen <= 2019.6.20;python_version<"3.6"',
+                                 'pymatgen;python_version >= "3.6"']},
         python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
         entry_points={
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ if __name__ == "__main__":
                                  "sphinx_rtd_theme",
                                  "sphinx-argparse",
                                  "sphinxcontrib-bibtex"],
-                        'vasp': ['pymatgen <= 2019.6.20;python_version<"3.6"',
+                        'vasp': ['pymatgen == 2018.1.19;python_version ~= "3.4"',
+                                 'ruamel.yaml ~= 0.15;python_version ~= "3.4"',
+                                 'numpy ~= 1.16;python_version ~= "3.4"',
+                                 'pymatgen <= 2019.6.20;python_version ~= "3.5"',
                                  'pymatgen;python_version >= "3.6"']},
         python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
                                  "sphinx-argparse",
                                  "sphinxcontrib-bibtex"],
                         'vasp': ['pymatgen == 2018.1.19;python_version ~= "3.4"',
-                                 'ruamel.yaml ~= 0.15;python_version ~= "3.4"',
+                                 'ruamel.yaml <= 0.15.94;python_version ~= "3.4"',
                                  'numpy ~= 1.16;python_version ~= "3.4"',
                                  'pymatgen <= 2019.6.20;python_version ~= "3.5"',
                                  'pymatgen;python_version >= "3.6"']},


### PR DESCRIPTION
Created a 'vasp' option to installation with setuptools which should detect the Python version and install a compatible pymatgen.

Probably going to take a few attempts to make it work as this is the first time I've used this setup.py trick...

Also I can't seem to make a Python 3.4 environment in a recent version of Anaconda, so just sending it to Travis seems to be the best way of trying this out!