### PR TITLE
Implement x-axis flip for simple TDOS mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Versioning <http://semver.org/>`__. The changelog format is inspired by
 
 `Unreleased <https://github.com/smtg-ucl/galore/compare/0.8.0...HEAD>`__
 -------------------------------------------------------------------------
+- Allow --xflip to be used with simple 1-d data plots (@ajjackson)
 - BUGFIX: Import type annoations from collection.abc. This is required
   for Python 3.10, which deprecates the original location. (@Hashan-Peiris)
 

--- a/galore/__init__.py
+++ b/galore/__init__.py
@@ -73,9 +73,6 @@ def process_1d_data(input=['vasprun.xml'],
 
     """
 
-    if 'flipx' in kwargs and kwargs['flipx']:
-        raise Exception("x-flip not currently implemented in 1D mode.")
-
     if type(input) == str:
         pass
     elif len(input) > 1:

--- a/galore/cli/galore.py
+++ b/galore/cli/galore.py
@@ -170,15 +170,15 @@ def simple_dos_from_files(return_plt=False, **kwargs):
             else:
                 plt.show()
 
-    if kwargs['csv'] is None:
-        galore.formats.write_csv(x_values, broadened_data, filename=None)
-    elif kwargs['csv']:
+    if kwargs['flipx']:
+        x_values = np.flip(-x_values)
+        broadened_data = np.flip(broadened_data)
+
+    if kwargs['csv'] or (kwargs['csv'] is None):
         galore.formats.write_csv(
             x_values, broadened_data, filename=kwargs['csv'])
 
-    if kwargs['txt'] is None:
-        galore.formats.write_txt(x_values, broadened_data, filename=None)
-    elif kwargs['txt']:
+    if kwargs['txt'] or (kwargs['txt'] is None):
         galore.formats.write_txt(
             x_values, broadened_data, filename=kwargs['txt'])
 


### PR DESCRIPTION
Requested by @Ckalha96

When plotting one set of data at a time (i.e. not PDOS mode) the `--xflip` argument was disabled. This was already implemented in the plotting code, so presumably was only disabled to avoid inconsistency with output files. However, it only takes a few lines of code to make it work for .txt and .csv outputs as well!

Rather than add arguments to various writers, in this implementation we transform the data once between plotting and writing.

Ultimately it could be simpler to do it this way everywhere; now we have a mixture of approaches which is not ideal. But would prefer not to

- Add extra arguments everywhere
- Break existing API without a major version update.

Maybe cleaning this up should be on the wishlist for Version 2?